### PR TITLE
Ft drafter

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
         <activity android:name=".ActivityMarket"
             android:label="@string/market_title" />
 
+        <activity android:name=".ActivityDrafter"
+                  android:label="Drafter" />
+
         <activity android:name=".settings.ActivityOptions"
             android:label="@string/options" />
 

--- a/app/src/main/java/ca/marklauman/dominionpicker/ActivityDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/ActivityDrafter.java
@@ -46,7 +46,8 @@ public class ActivityDrafter extends AppCompatActivity  implements AdapterCards.
         // listen for card clicks
         cardsAdapter.setListener(this);
 
-        // start shuffling of 3* kingdom cards required
+        // start shuffling of DRAFT_NUMBER_OF_CHOICES * kingdom cards required
+        cardsToDraft = Pref.get(this).getInt(Pref.DRAFT_NUMBER_OF_CHOICES, 3);
         DraftShufflerTask shuffleTask = new DraftShufflerTask();
         shuffleTask.execute();
 
@@ -57,7 +58,7 @@ public class ActivityDrafter extends AppCompatActivity  implements AdapterCards.
     }
 
     final int numKingdoms = Pref.get(Pref.getAppContext()).getInt(Pref.LIMIT_SUPPLY, 10);
-    final int cardsToDraft = 3; // TODO: make this a setting in FragmentDrafter
+    int cardsToDraft;
     int draftIndex = 0; // the index of the currently drafted card
     CardCollection draftCandidates; // current draft candidates
     CardCollection draftSource;

--- a/app/src/main/java/ca/marklauman/dominionpicker/ActivityDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/ActivityDrafter.java
@@ -1,0 +1,157 @@
+package ca.marklauman.dominionpicker;
+
+import android.content.ContentValues;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.Loader;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import ca.marklauman.dominionpicker.database.DataDb;
+import ca.marklauman.dominionpicker.database.LoaderId;
+import ca.marklauman.dominionpicker.database.Provider;
+import ca.marklauman.dominionpicker.settings.Pref;
+import ca.marklauman.dominionpicker.userinterface.recyclerview.AdapterCards;
+import ca.marklauman.tools.Utils;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+/**
+ * @author Botond Xantus
+ */
+public class ActivityDrafter extends AppCompatActivity  implements AdapterCards.Listener {
+    @BindView(android.R.id.list)
+    RecyclerView cardList;
+    private AdapterCards cardsAdapter;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_drafter);
+        ButterKnife.bind(this);
+
+        cardsAdapter = new AdapterCards(cardList);
+        cardList.setAdapter(cardsAdapter);
+        cardList.setLayoutManager(new LinearLayoutManager(this));
+        // listen for card clicks
+        cardsAdapter.setListener(this);
+
+        // start shuffling of 3* kingdom cards required
+        DraftShufflerTask shuffleTask = new DraftShufflerTask();
+        shuffleTask.execute();
+
+        // TODO: extract current state form savedInstanceState
+
+        draftResults = new ArrayList<>();
+        draftIndex = 0;
+    }
+
+    final int numKingdoms = Pref.get(Pref.getAppContext()).getInt(Pref.LIMIT_SUPPLY, 10);
+    final int cardsToDraft = 3; // TODO: make this a setting in FragmentDrafter
+    int draftIndex = 0; // the index of the currently drafted card
+    CardCollection draftCandidates; // current draft candidates
+    CardCollection draftSource;
+    List<Long> draftResults; // draft results are stored in this collection
+
+    void supplyReady(SupplyShuffler.ShuffleSupply supply) {
+        draftSource = new CardCollection(supply.getCards());
+        nextDraftCandidates();
+    }
+
+    void nextDraftCandidates() {
+        // show the next 3 cards of the result
+        getSupportLoaderManager().restartLoader(LoaderId.DRAFT_CARDS, null, new CardLoaderCallbacks());
+    }
+
+    @Override
+    public void onItemClick(AdapterCards.ViewHolder holder, int position, long id, boolean longClick) {
+        onCandidateSelected(position);
+    }
+
+    void onCandidateSelected(int idx) {
+        // add selected to the result supply
+        draftResults.add(cardsAdapter.getItemId(idx));
+        cardsAdapter.changeCursor(null);
+
+        // TODO: update draft progress display
+        // check if all cards are drafted
+        if (draftResults.size() == numKingdoms) {
+            // TODO: extract common notification code (currently this is copied from SupplyShufflerTask
+            long time = Calendar.getInstance().getTimeInMillis();
+            ContentValues values = new ContentValues();
+            values.putNull(DataDb._H_NAME);
+            values.put(DataDb._H_TIME,      time);
+            values.put(DataDb._H_CARDS,     Utils.join(",", draftResults));
+            values.put(DataDb._H_BANE,      -1);
+            values.put(DataDb._H_HIGH_COST, false);
+            values.put(DataDb._H_SHELTERS,  false);
+            Pref.getAppContext()
+                    .getContentResolver()
+                    .insert(Provider.URI_HIST, values);
+
+            // let the listeners know the result
+            Intent msg = new Intent(SupplyShufflerTask.MSG_INTENT);
+            msg.putExtra(SupplyShufflerTask.MSG_RES, SupplyShufflerTask.RES_OK);
+            msg.putExtra(SupplyShufflerTask.MSG_SUPPLY_ID, time);
+            SupplyShufflerTask.sendMsg(msg);
+
+            // drafter is done, remove it from activity stack
+            finish();
+        } else { // if not, show the next 3 cards
+            // TODO: empty candidate list, while loading (or freeze it)
+            draftIndex++;
+            nextDraftCandidates();
+        }
+    }
+
+    private class CardLoaderCallbacks implements LoaderManager.LoaderCallbacks<Cursor> {
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+            final int rangeStart = draftIndex * cardsToDraft;
+            draftCandidates = draftSource.subCollection(rangeStart, rangeStart + cardsToDraft);
+            return CardCollection.createLoader(draftCandidates, ActivityDrafter.this);
+        }
+
+        @Override
+        public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
+            cardsAdapter.changeCursor(data);
+        }
+
+        @Override
+        public void onLoaderReset(Loader<Cursor> loader) {
+            // nop
+        }
+    }
+
+    private class DraftShufflerTask extends AsyncTask<Void, Void, SupplyShuffler.ShuffleSupply> {
+        @Override
+        protected SupplyShuffler.ShuffleSupply doInBackground(Void... voids) {
+            SharedPreferences pref = Pref.get(Pref.getAppContext());
+
+            final int numKingdomsToDraft = numKingdoms * cardsToDraft;
+            final int numSpecial = 0; // TODO: decide how to draft special cards (events/landmarks), have to check the rules
+            SupplyShuffler.ShuffleSupply supply = new SupplyShuffler.ShuffleSupply(numKingdomsToDraft, numSpecial);
+
+            SupplyShuffler.ShuffleResult result = SupplyShuffler.fillSupply(supply, this);
+            if (result == SupplyShuffler.ShuffleResult.SUCCESS) return supply;
+            else return null;
+        }
+
+        @Override
+        protected void onPostExecute(SupplyShuffler.ShuffleSupply shuffleSupply) {
+            // notify caller about the new fancy supply
+            // TODO: handle errors!
+            supplyReady(shuffleSupply);
+        }
+    }
+}

--- a/app/src/main/java/ca/marklauman/dominionpicker/ActivityDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/ActivityDrafter.java
@@ -214,7 +214,7 @@ public class ActivityDrafter extends AppCompatActivity  implements AdapterCards.
         @Override
         protected void onPostExecute(SupplyShuffler.ShuffleSupply shuffleSupply) {
             // notify caller about the new fancy supply
-            if (shuffleSupply.getNumberOfCards() == numKingdomsToDraft)
+            if (shuffleSupply.getNumberOfCards() >= numKingdomsToDraft) // there could be more cards because of the selected landmarks
                 supplyReady(shuffleSupply);
             else {
                 // send not enough cards warning

--- a/app/src/main/java/ca/marklauman/dominionpicker/ActivityDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/ActivityDrafter.java
@@ -220,7 +220,7 @@ public class ActivityDrafter extends AppCompatActivity  implements AdapterCards.
                 // send not enough cards warning
                 Intent msg = new Intent(MSG_INTENT);
                 msg.putExtra(MSG_RES, RES_MORE);
-                msg.putExtra(MSG_SHORT, numKingdomsToDraft - shuffleSupply.getNumberOfCards());
+                msg.putExtra(MSG_SHORT, String.format("%d/%d", shuffleSupply.getNumberOfCards(), numKingdomsToDraft));
                 LocalBroadcastManager.getInstance(ActivityDrafter.this).sendBroadcast(msg);
                 finish();
             }

--- a/app/src/main/java/ca/marklauman/dominionpicker/ActivitySupply.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/ActivitySupply.java
@@ -257,18 +257,7 @@ public class ActivitySupply extends AppCompatActivity
             vLoading.setVisibility(View.VISIBLE);
             adapter.changeCursor(null);
 
-            // Basic loader
-            CursorLoader c = new CursorLoader(getActivity());
-            c.setUri(Provider.URI_CARD_ALL);
-            c.setProjection(AdapterCardsDismiss.COLS_USED);
-            c.setSortOrder(Pref.cardSort(ActivitySupply.this));
-
-            // Selection string (sql WHERE clause)
-            // _id IN (1,2,3,4)
-            String cards = TableCard._ID+" IN ("+ Utils.join(",",supply.cards)+")";
-            c.setSelection("("+cards+") AND "+ Pref.languageFilter(ActivitySupply.this));
-
-            return c;
+            return CardCollection.createLoader(new CardCollection(supply.cards), getActivity());
         }
 
 

--- a/app/src/main/java/ca/marklauman/dominionpicker/ActivitySupply.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/ActivitySupply.java
@@ -34,6 +34,11 @@ import ca.marklauman.tools.Utils;
 import ca.marklauman.dominionpicker.userinterface.recyclerview.AdapterCardsDismiss;
 import ca.marklauman.tools.recyclerview.ListDivider;
 
+// TODO: extend this activity, or create new one based on it
+//       use small supply-s to represent one drafting sequence (for. ex 3 cards)
+//       the card adapter should contain also a Pick button as well.
+//       After a pick is done, a new supply should be shown
+
 /** Activity for displaying the supply piles for a new game.
  *  @author Mark Lauman */
 public class ActivitySupply extends AppCompatActivity

--- a/app/src/main/java/ca/marklauman/dominionpicker/ActivitySupply.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/ActivitySupply.java
@@ -34,11 +34,6 @@ import ca.marklauman.tools.Utils;
 import ca.marklauman.dominionpicker.userinterface.recyclerview.AdapterCardsDismiss;
 import ca.marklauman.tools.recyclerview.ListDivider;
 
-// TODO: extend this activity, or create new one based on it
-//       use small supply-s to represent one drafting sequence (for. ex 3 cards)
-//       the card adapter should contain also a Pick button as well.
-//       After a pick is done, a new supply should be shown
-
 /** Activity for displaying the supply piles for a new game.
  *  @author Mark Lauman */
 public class ActivitySupply extends AppCompatActivity

--- a/app/src/main/java/ca/marklauman/dominionpicker/CardCollection.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/CardCollection.java
@@ -1,6 +1,9 @@
 package ca.marklauman.dominionpicker;
 
 import android.content.Context;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.Nullable;
 import android.support.v4.content.CursorLoader;
 import ca.marklauman.dominionpicker.database.Provider;
 import ca.marklauman.dominionpicker.database.TableCard;
@@ -16,7 +19,7 @@ import java.util.List;
  * Collection of dominion cards. This only stores the card id-s.
  * @author Botond Xantus
  */
-public class CardCollection {
+public class CardCollection implements Parcelable {
     public final List<Long> cards;
 
     public CardCollection(List<Long> source) {
@@ -47,9 +50,35 @@ public class CardCollection {
 
         // Selection string (sql WHERE clause)
         // _id IN (1,2,3,4)
-        String cards = TableCard._ID+" IN ("+ Utils.join(",",coll.cards)+")";
-        c.setSelection("("+cards+") AND "+ Pref.languageFilter(ctx));
+        String cards = TableCard._ID + " IN (" + Utils.join(",", coll.cards) + ")";
+        c.setSelection("(" + cards + ") AND " + Pref.languageFilter(ctx));
 
         return c;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int flags) {
+        long[] content = new long[cards.size()];
+        for (int i = 0; i < cards.size(); ++i) content[i] = cards.get(i);
+        parcel.writeLongArray(content);
+    }
+
+    public static final Parcelable.Creator<CardCollection> CREATOR = new Parcelable.Creator<CardCollection>() {
+        @Override
+        public CardCollection createFromParcel(Parcel parcel) {
+            long[] cards = parcel.createLongArray();
+            return new CardCollection(cards);
+        }
+
+        @Override
+        public CardCollection[] newArray(int size) {
+            return new CardCollection[size];
+        }
+    };
+
 }

--- a/app/src/main/java/ca/marklauman/dominionpicker/CardCollection.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/CardCollection.java
@@ -1,6 +1,15 @@
 package ca.marklauman.dominionpicker;
 
+import android.content.Context;
+import android.support.v4.content.CursorLoader;
+import ca.marklauman.dominionpicker.database.Provider;
+import ca.marklauman.dominionpicker.database.TableCard;
+import ca.marklauman.dominionpicker.settings.Pref;
+import ca.marklauman.dominionpicker.userinterface.recyclerview.AdapterCardsDismiss;
+import ca.marklauman.tools.Utils;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -13,7 +22,10 @@ public class CardCollection {
     public CardCollection(List<Long> source) {
         cards = new ArrayList<>(source);
     }
-
+    public CardCollection(long[] source) {
+        cards = new ArrayList<>(source.length);
+        for (long card : source) cards.add(card);
+    }
     /**
      * creates an empty collection
      */
@@ -23,5 +35,21 @@ public class CardCollection {
 
     public CardCollection subCollection(int fromIndex, int toIndex) {
         return new CardCollection(cards.subList(fromIndex, toIndex));
+    }
+
+    // some utility methods with collections
+    public static CursorLoader createLoader(CardCollection coll, Context ctx) {
+        // Basic loader
+        CursorLoader c = new CursorLoader(ctx);
+        c.setUri(Provider.URI_CARD_ALL);
+        c.setProjection(AdapterCardsDismiss.COLS_USED);
+        c.setSortOrder(Pref.cardSort(ctx));
+
+        // Selection string (sql WHERE clause)
+        // _id IN (1,2,3,4)
+        String cards = TableCard._ID+" IN ("+ Utils.join(",",coll.cards)+")";
+        c.setSelection("("+cards+") AND "+ Pref.languageFilter(ctx));
+
+        return c;
     }
 }

--- a/app/src/main/java/ca/marklauman/dominionpicker/CardCollection.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/CardCollection.java
@@ -1,0 +1,27 @@
+package ca.marklauman.dominionpicker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collection of dominion cards. This only stores the card id-s.
+ * @author Botond Xantus
+ */
+public class CardCollection {
+    public final List<Long> cards;
+
+    public CardCollection(List<Long> source) {
+        cards = new ArrayList<>(source);
+    }
+
+    /**
+     * creates an empty collection
+     */
+    public CardCollection() {
+        cards = new ArrayList<>();
+    }
+
+    public CardCollection subCollection(int fromIndex, int toIndex) {
+        return new CardCollection(cards.subList(fromIndex, toIndex));
+    }
+}

--- a/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
@@ -1,42 +1,23 @@
 package ca.marklauman.dominionpicker;
 
-import android.content.ContentValues;
+
 import android.content.Intent;
-import android.content.SharedPreferences;
-import android.database.Cursor;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.LoaderManager;
-import android.support.v4.content.Loader;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import ca.marklauman.dominionpicker.database.DataDb;
-import ca.marklauman.dominionpicker.database.LoaderId;
-import ca.marklauman.dominionpicker.database.Provider;
-import ca.marklauman.dominionpicker.settings.Pref;
-import ca.marklauman.dominionpicker.userinterface.recyclerview.AdapterCards;
-import ca.marklauman.tools.Utils;
-
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
 
 /**
  * Fragment representing drafter setup
  * @author Botond Xantus
  */
-public class FragmentDrafter extends Fragment implements AdapterCards.Listener{
+public class FragmentDrafter extends Fragment{
     @BindView(R.id.drafting_start) Button startButton;
-    @BindView(android.R.id.list) RecyclerView cardList;
-    private AdapterCards cardsAdapter;
 
     @Nullable
     @Override
@@ -44,11 +25,6 @@ public class FragmentDrafter extends Fragment implements AdapterCards.Listener{
         View view = inflater.inflate(R.layout.fragment_drafter, container, false);
         ButterKnife.bind(this, view);
 
-        cardsAdapter = new AdapterCards(cardList);
-        cardList.setAdapter(cardsAdapter);
-        cardList.setLayoutManager(new LinearLayoutManager(getContext()));
-        // listen for card clicks
-        cardsAdapter.setListener(this);
         startButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -61,107 +37,10 @@ public class FragmentDrafter extends Fragment implements AdapterCards.Listener{
     // TODO: move the code below to DraftingActivity
 
     private void startDrafting(){
-        // start shuffling of 3* kingdom cards required
-        DraftShufflerTask shuffleTask = new DraftShufflerTask();
-        shuffleTask.execute();
+        Intent startDrafting = new Intent(getContext(), ActivityDrafter.class);
+        getContext().startActivity(startDrafting);
+
     }
 
-    final int numKingdoms = Pref.get(Pref.getAppContext()).getInt(Pref.LIMIT_SUPPLY, 10);
-    final int cardsToDraft = 3; // TODO: make this a setting in FragmentDrafter
-    int draftIndex = 0; // the index of the currently drafted card
-    CardCollection draftCandidates; // current draft candidates
-    CardCollection draftSource;
-    List<Long> draftResults; // draft results are stored in this collection
 
-    void supplyReady(SupplyShuffler.ShuffleSupply supply) {
-        draftSource = new CardCollection(supply.getCards());
-
-        draftResults = new ArrayList<>();
-        draftIndex = 0;
-        nextDraftCandidates();
-    }
-
-    void nextDraftCandidates() {
-        // show the next 3 cards of the result
-        getLoaderManager().restartLoader(LoaderId.DRAFT_CARDS, null, new CardLoaderCallbacks());
-    }
-
-    @Override
-    public void onItemClick(AdapterCards.ViewHolder holder, int position, long id, boolean longClick) {
-        onCandidateSelected(position);
-    }
-
-    void onCandidateSelected(int idx) {
-        // add selected to the result supply
-        draftResults.add(cardsAdapter.getItemId(idx));
-        cardsAdapter.changeCursor(null);
-
-        // TODO: update draft progress display
-        // check if all cards are drafted
-        if (draftResults.size() == numKingdoms) {
-            // TODO: extract common notification code (currently this is copied from SupplyShufflerTask
-            long time = Calendar.getInstance().getTimeInMillis();
-            ContentValues values = new ContentValues();
-            values.putNull(DataDb._H_NAME);
-            values.put(DataDb._H_TIME,      time);
-            values.put(DataDb._H_CARDS,     Utils.join(",", draftResults));
-            values.put(DataDb._H_BANE,      -1);
-            values.put(DataDb._H_HIGH_COST, false);
-            values.put(DataDb._H_SHELTERS,  false);
-            Pref.getAppContext()
-                    .getContentResolver()
-                    .insert(Provider.URI_HIST, values);
-
-            // let the listeners know the result
-            Intent msg = new Intent(SupplyShufflerTask.MSG_INTENT);
-            msg.putExtra(SupplyShufflerTask.MSG_RES, SupplyShufflerTask.RES_OK);
-            msg.putExtra(SupplyShufflerTask.MSG_SUPPLY_ID, time);
-            SupplyShufflerTask.sendMsg(msg);
-        } else { // if not, show the next 3 cards
-            // TODO: empty candidate list, while loading (or freeze it)
-            draftIndex++;
-            nextDraftCandidates();
-        }
-    }
-
-    private class CardLoaderCallbacks implements LoaderManager.LoaderCallbacks<Cursor> {
-        @Override
-        public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-            final int rangeStart = draftIndex * cardsToDraft;
-            draftCandidates = draftSource.subCollection(rangeStart, rangeStart + cardsToDraft);
-            return CardCollection.createLoader(draftCandidates, FragmentDrafter.this.getContext());
-        }
-
-        @Override
-        public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
-            cardsAdapter.changeCursor(data);
-        }
-
-        @Override
-        public void onLoaderReset(Loader<Cursor> loader) {
-            // nop
-        }
-    }
-
-    private class DraftShufflerTask extends AsyncTask<Void, Void, SupplyShuffler.ShuffleSupply> {
-        @Override
-        protected SupplyShuffler.ShuffleSupply doInBackground(Void... voids) {
-            SharedPreferences pref = Pref.get(Pref.getAppContext());
-
-            final int numKingdomsToDraft = numKingdoms * cardsToDraft;
-            final int numSpecial = 0; // TODO: decide how to draft special cards (events/landmarks), have to check the rules
-            SupplyShuffler.ShuffleSupply supply = new SupplyShuffler.ShuffleSupply(numKingdomsToDraft, numSpecial);
-
-            SupplyShuffler.ShuffleResult result = SupplyShuffler.fillSupply(supply, this);
-            if (result == SupplyShuffler.ShuffleResult.SUCCESS) return supply;
-            else return null;
-        }
-
-        @Override
-        protected void onPostExecute(SupplyShuffler.ShuffleSupply shuffleSupply) {
-            // notify caller about the new fancy supply
-            // TODO: handle errors!
-            supplyReady(shuffleSupply);
-        }
-    }
 }

--- a/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
@@ -60,7 +60,7 @@ public class FragmentDrafter extends Fragment {
             final int numSpecial = 0; // TODO: decide how to draft special cards (events/landmarks), have to check the rules
             SupplyShuffler.ShuffleSupply supply = new SupplyShuffler.ShuffleSupply(numKingdoms, numSpecial);
 
-            SupplyShuffler.ShuffleResult result = SupplyShuffler.FillSupply(supply, this);
+            SupplyShuffler.ShuffleResult result = SupplyShuffler.fillSupply(supply, this);
             if (result == SupplyShuffler.ShuffleResult.SUCCESS) return supply;
             else return null;
         }

--- a/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
@@ -22,6 +22,7 @@ import ca.marklauman.tools.preferences.SmallNumberPreference;
 public class FragmentDrafter extends Fragment{
     @BindView(R.id.drafting_start) Button startButton;
     @BindView(R.id.pref_number_of_choices) SmallNumberPreference numberOfChoices;
+    @BindView(R.id.pref_number_of_picks) SmallNumberPreference numberOfPicks;
     @BindView(R.id.cb_reshuffle) CheckBox cbReshuffle;
 
     @Nullable
@@ -36,8 +37,11 @@ public class FragmentDrafter extends Fragment{
                 startDrafting();
             }
         });
+        // TODO: why doesn't android:key and android:text work in resource xml?
         numberOfChoices.setKey(Pref.DRAFT_NUMBER_OF_CHOICES);
-        numberOfChoices.setText("Number of choices"); // TODO: why doesn't android:key and android:text work in resource xml?
+        numberOfChoices.setText("Number of choices");
+        numberOfPicks.setKey(Pref.DRAFT_NUMBER_OF_PICKS);
+        numberOfPicks.setText("Autopicks");
         return view;
     }
 

--- a/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
@@ -9,8 +9,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.CheckBox;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import ca.marklauman.dominionpicker.settings.Pref;
+import ca.marklauman.tools.preferences.SmallNumberPreference;
 
 /**
  * Fragment representing drafter setup
@@ -18,6 +21,8 @@ import butterknife.ButterKnife;
  */
 public class FragmentDrafter extends Fragment{
     @BindView(R.id.drafting_start) Button startButton;
+    @BindView(R.id.pref_number_of_choices) SmallNumberPreference numberOfChoices;
+    @BindView(R.id.cb_reshuffle) CheckBox cbReshuffle;
 
     @Nullable
     @Override
@@ -31,10 +36,10 @@ public class FragmentDrafter extends Fragment{
                 startDrafting();
             }
         });
+        numberOfChoices.setKey(Pref.DRAFT_NUMBER_OF_CHOICES);
+        numberOfChoices.setText("Number of choices"); // TODO: why doesn't android:key and android:text work in resource xml?
         return view;
     }
-
-    // TODO: move the code below to DraftingActivity
 
     private void startDrafting(){
         Intent startDrafting = new Intent(getContext(), ActivityDrafter.class);

--- a/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
@@ -1,14 +1,18 @@
 package ca.marklauman.dominionpicker;
 
+import android.content.SharedPreferences;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import ca.marklauman.dominionpicker.settings.Pref;
 
 /**
  * Fragment representing drafter setup
@@ -16,12 +20,54 @@ import butterknife.ButterKnife;
  */
 public class FragmentDrafter extends Fragment {
     @BindView(R.id.drafting_start) Button startButton;
+    @BindView(android.R.id.list) RecyclerView cardList;
 
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_drafter, container, false);
         ButterKnife.bind(this, view);
+
+        startButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                startDrafting();
+            }
+        });
         return view;
+    }
+
+    // TODO: move the code below to DraftingActivity
+
+    private void startDrafting(){
+        // start shuffling of 3* kingdom cards required
+        DraftShufflerTask shuffleTask = new DraftShufflerTask();
+        shuffleTask.execute();
+        // when done, show the first 3 cards of the result
+        // while not all cards selected
+        //    select one of the 3 cards -> add it to the result supply
+        //    show the next 3 cards
+
+
+    }
+
+    private class DraftShufflerTask extends AsyncTask<Void, Void, SupplyShuffler.ShuffleSupply> {
+        @Override
+        protected SupplyShuffler.ShuffleSupply doInBackground(Void... voids) {
+            SharedPreferences pref = Pref.get(Pref.getAppContext());
+            final int cardsToDraft = 3; // TODO: make this a setting in FragmentDrafter
+            final int numKingdoms = pref.getInt(Pref.LIMIT_SUPPLY, 10) * cardsToDraft;
+            final int numSpecial = 0; // TODO: decide how to draft special cards (events/landmarks), have to check the rules
+            SupplyShuffler.ShuffleSupply supply = new SupplyShuffler.ShuffleSupply(numKingdoms, numSpecial);
+
+            SupplyShuffler.ShuffleResult result = SupplyShuffler.FillSupply(supply, this);
+            if (result == SupplyShuffler.ShuffleResult.SUCCESS) return supply;
+            else return null;
+        }
+
+        @Override
+        protected void onPostExecute(SupplyShuffler.ShuffleSupply shuffleSupply) {
+            // notify caller about the new fancy supply
+        }
     }
 }

--- a/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
@@ -1,0 +1,27 @@
+package ca.marklauman.dominionpicker;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ * Fragment representing drafter setup
+ * @author Botond Xantus
+ */
+public class FragmentDrafter extends Fragment {
+    @BindView(R.id.drafting_start) Button startButton;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_drafter, container, false);
+        ButterKnife.bind(this, view);
+        return view;
+    }
+}

--- a/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/FragmentDrafter.java
@@ -1,10 +1,13 @@
 package ca.marklauman.dominionpicker;
 
 import android.content.SharedPreferences;
+import android.database.Cursor;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.Loader;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -12,15 +15,21 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import ca.marklauman.dominionpicker.database.LoaderId;
 import ca.marklauman.dominionpicker.settings.Pref;
+import ca.marklauman.dominionpicker.userinterface.recyclerview.AdapterCards;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Fragment representing drafter setup
  * @author Botond Xantus
  */
-public class FragmentDrafter extends Fragment {
+public class FragmentDrafter extends Fragment implements AdapterCards.Listener{
     @BindView(R.id.drafting_start) Button startButton;
     @BindView(android.R.id.list) RecyclerView cardList;
+    private AdapterCards cardsAdapter;
 
     @Nullable
     @Override
@@ -28,6 +37,10 @@ public class FragmentDrafter extends Fragment {
         View view = inflater.inflate(R.layout.fragment_drafter, container, false);
         ButterKnife.bind(this, view);
 
+        cardsAdapter = new AdapterCards(cardList);
+        cardList.setAdapter(cardsAdapter);
+        // listen for card clicks
+        cardsAdapter.setListener(this);
         startButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -43,20 +56,74 @@ public class FragmentDrafter extends Fragment {
         // start shuffling of 3* kingdom cards required
         DraftShufflerTask shuffleTask = new DraftShufflerTask();
         shuffleTask.execute();
-        // when done, show the first 3 cards of the result
-        // while not all cards selected
-        //    select one of the 3 cards -> add it to the result supply
-        //    show the next 3 cards
+    }
 
+    final int numKingdoms = Pref.get(Pref.getAppContext()).getInt(Pref.LIMIT_SUPPLY, 10);
+    final int cardsToDraft = 3; // TODO: make this a setting in FragmentDrafter
+    int draftIndex = 0; // the index of the currently drafted card
+    CardCollection draftCandidates; // current draft candidates
+    CardCollection draftSource;
+    List<Long> draftResults; // draft results are stored in this collection
 
+    void supplyReady(SupplyShuffler.ShuffleSupply supply) {
+        draftSource = new CardCollection(supply.getCards());
+
+        draftResults = new ArrayList<>();
+        draftIndex = 0;
+        nextDraftCandidates();
+    }
+
+    void nextDraftCandidates() {
+        // show the next 3 cards of the result
+        getLoaderManager().restartLoader(LoaderId.DRAFT_CARDS, null, new CardLoaderCallbacks());
+    }
+
+    @Override
+    public void onItemClick(AdapterCards.ViewHolder holder, int position, long id, boolean longClick) {
+        onCandidateSelected(position);
+    }
+
+    void onCandidateSelected(int idx) {
+        // add selected to the result supply
+        draftResults.add(draftCandidates.cards.get(idx));
+
+        // TODO: update draft progress display
+        // check if all cards are drafted
+        if (draftResults.size() == numKingdoms) {
+            // TODO: notify app that a new supply is ready => save to history, start supply activity
+        } else { // if not, show the next 3 cards
+            // TODO: empty candidate list, while loading (or freeze it)
+            cardsAdapter.changeCursor(null);
+            draftIndex++;
+            nextDraftCandidates();
+        }
+    }
+
+    private class CardLoaderCallbacks implements LoaderManager.LoaderCallbacks<Cursor> {
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+            final int rangeStart = draftIndex * cardsToDraft;
+            draftCandidates = draftSource.subCollection(rangeStart, rangeStart + cardsToDraft);
+            return CardCollection.createLoader(draftCandidates, FragmentDrafter.this.getContext());
+        }
+
+        @Override
+        public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
+            cardsAdapter.changeCursor(data);
+        }
+
+        @Override
+        public void onLoaderReset(Loader<Cursor> loader) {
+            // nop
+        }
     }
 
     private class DraftShufflerTask extends AsyncTask<Void, Void, SupplyShuffler.ShuffleSupply> {
         @Override
         protected SupplyShuffler.ShuffleSupply doInBackground(Void... voids) {
             SharedPreferences pref = Pref.get(Pref.getAppContext());
-            final int cardsToDraft = 3; // TODO: make this a setting in FragmentDrafter
-            final int numKingdoms = pref.getInt(Pref.LIMIT_SUPPLY, 10) * cardsToDraft;
+
+            final int numKingdomsToDraft = numKingdoms * cardsToDraft;
             final int numSpecial = 0; // TODO: decide how to draft special cards (events/landmarks), have to check the rules
             SupplyShuffler.ShuffleSupply supply = new SupplyShuffler.ShuffleSupply(numKingdoms, numSpecial);
 
@@ -68,6 +135,8 @@ public class FragmentDrafter extends Fragment {
         @Override
         protected void onPostExecute(SupplyShuffler.ShuffleSupply shuffleSupply) {
             // notify caller about the new fancy supply
+            // TODO: handle errors!
+            supplyReady(shuffleSupply);
         }
     }
 }

--- a/app/src/main/java/ca/marklauman/dominionpicker/MainActivity.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/MainActivity.java
@@ -88,7 +88,7 @@ public class MainActivity extends AppCompatActivity
         String[] headers = getResources().getStringArray(R.array.navNames);
         navAdapt = new ExpandedArrayAdapter<>(this, R.layout.nav_drawer_item, headers);
         navAdapt.setIcons(R.drawable.ic_core_checkbox, R.drawable.ic_card,
-                          R.drawable.ic_cards, R.drawable.ic_action_market);
+                          R.drawable.ic_cards, R.drawable.ic_action_market, R.drawable.ic_core_code);
         navAdapt.setSelBack(R.color.list_item_sel);
         ListView navList = (ListView) vDrawer.findViewById(R.id.drawer_list);
         navList.setAdapter(navAdapt);
@@ -201,6 +201,10 @@ public class MainActivity extends AppCompatActivity
                     break;
             case 3: active = new FragmentMarket();
                     t.replace(R.id.content_frame, active);
+                    break;
+            case 4: active = new FragmentDrafter();
+                    t.replace(R.id.content_frame, active);
+                    vSubmit.show();
                     break;
         }
         t.commit();

--- a/app/src/main/java/ca/marklauman/dominionpicker/MainActivity.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/MainActivity.java
@@ -260,13 +260,13 @@ public class MainActivity extends AppCompatActivity
     private class ShuffleManager extends BroadcastReceiver
                                  implements View.OnClickListener {
         /** The shuffler */
-        private SupplyShuffler shuffler;
+        private SupplyShufflerTask shuffler;
 
         public ShuffleManager() {
             super();
             shuffler = null;
             LocalBroadcastManager.getInstance(getActivity())
-                    .registerReceiver(this, new IntentFilter(SupplyShuffler.MSG_INTENT));
+                    .registerReceiver(this, new IntentFilter(SupplyShufflerTask.MSG_INTENT));
         }
 
         @Override
@@ -281,22 +281,22 @@ public class MainActivity extends AppCompatActivity
         @Override
         public void onReceive(Context context, Intent intent) {
             shuffler = null;
-            int res = intent.getIntExtra(SupplyShuffler.MSG_RES, -100);
+            int res = intent.getIntExtra(SupplyShufflerTask.MSG_RES, -100);
             String msg;
             switch(res) {
-                case SupplyShuffler.RES_OK:
+                case SupplyShufflerTask.RES_OK:
                     Intent showSupply = new Intent(getActivity(), ActivitySupply.class);
                     showSupply.putExtra(ActivitySupply.PARAM_HISTORY_ID,
-                                        intent.getLongExtra(SupplyShuffler.MSG_SUPPLY_ID, -1));
+                                        intent.getLongExtra(SupplyShufflerTask.MSG_SUPPLY_ID, -1));
                     startActivity(showSupply);
                     return;
-                case SupplyShuffler.RES_MORE:
+                case SupplyShufflerTask.RES_MORE:
                     msg = String.format(getString(R.string.more_k),
-                                        intent.getStringExtra(SupplyShuffler.MSG_SHORT));
+                                        intent.getStringExtra(SupplyShufflerTask.MSG_SHORT));
                     Toast.makeText(getActivity(), msg, Toast.LENGTH_LONG)
                          .show();
                     return;
-                case SupplyShuffler.RES_NO_YW:
+                case SupplyShufflerTask.RES_NO_YW:
                     Toast.makeText(getActivity(), R.string.yw_no_bane, Toast.LENGTH_LONG)
                          .show();
                     return;
@@ -308,7 +308,7 @@ public class MainActivity extends AppCompatActivity
          *  Also cancels any shuffles in progress. */
         public void startShuffle() {
             cancelShuffle();
-            shuffler = new SupplyShuffler();
+            shuffler = new SupplyShufflerTask();
             shuffler.execute();
         }
 

--- a/app/src/main/java/ca/marklauman/dominionpicker/Supply.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/Supply.java
@@ -9,6 +9,9 @@ import android.os.Parcelable;
 import ca.marklauman.dominionpicker.database.TableCard;
 import ca.marklauman.dominionpicker.database.TableSupply;
 
+// TODO: create some kind of collection  (like cardcollection) this could be the base of a drafting pack
+//       supply can reuse its code too
+
 /** Contains all information about a supply set.
  *  @author Mark Lauman                       */
 public class Supply implements Parcelable {

--- a/app/src/main/java/ca/marklauman/dominionpicker/Supply.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/Supply.java
@@ -9,9 +9,6 @@ import android.os.Parcelable;
 import ca.marklauman.dominionpicker.database.TableCard;
 import ca.marklauman.dominionpicker.database.TableSupply;
 
-// TODO: create some kind of collection  (like cardcollection) this could be the base of a drafting pack
-//       supply can reuse its code too
-
 /** Contains all information about a supply set.
  *  @author Mark Lauman                       */
 public class Supply implements Parcelable {

--- a/app/src/main/java/ca/marklauman/dominionpicker/SupplyShuffler.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/SupplyShuffler.java
@@ -4,8 +4,8 @@ import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.AsyncTask;
 
-import java.util.ArrayList;
-
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import ca.marklauman.dominionpicker.database.Provider;
 import ca.marklauman.dominionpicker.database.TableCard;
@@ -131,16 +131,20 @@ class SupplyShuffler {
         }
     }
 
-    /** Represents a supply in the process of being shuffled. */
-    static class ShuffleSupply {
-        /** Possible value of {@link #baneStatus}. There is no young witch in the supply. */
-        private static final int BANE_INACTIVE = 0;
-        /** Possible value of {@link #baneStatus}.
-         *  The young witch was drawn, but we haven't seen a bane yet */
-        private static final int BANE_WAITING = 1;
-        /** Possible value of {@link #baneStatus}. The bane and the young witch have been set */
-        private static final int BANE_ACTIVE = 2;
+    interface IKingdomInsertStrategy {
+        /// @return true if card with id should be inserted. supply may be used to do all kind of operations (side effects)
+        boolean handleKingdomInsertion(ShuffleSupply supply, long id, String cost, int set_id);
+    }
 
+    static class KingdomInsertAllStrategy implements IKingdomInsertStrategy {
+        @Override
+        public boolean handleKingdomInsertion(ShuffleSupply supply, long id, String cost, int set_id) {
+            return true;
+        }
+    }
+
+    /** Represents a supply in the process of being shuffled. */
+    static class ShuffleSupply implements Parcelable {
         /** Minimum amount of kingdom cards needed for this supply to be complete. */
         public int minKingdom;
         /** Maximum amount of special cards allowed. */
@@ -156,83 +160,68 @@ class SupplyShuffler {
         private final int shelterCard;
 
         /** Kingdom cards in this supply */
-        private final ArrayList<Long> kingdom;
+        private final CardCollection kingdom;
         /** Special cards in this supply that are not kingdom cards. */
-        private final ArrayList<Long> special;
-        /** Current status of the bane card */
-        private int baneStatus = BANE_INACTIVE;
+        private final CardCollection special;
+
         /** Id for a possible bane card */
         private long bane = -1L;
+        private boolean waitingForBane = false; // Check if the supply is waiting for a valid bane card.
+        private IKingdomInsertStrategy insertStrategy;
 
 
-        public ShuffleSupply(int numKingdoms, int numSpecials) {
+        public ShuffleSupply(int numKingdoms, int numSpecials, IKingdomInsertStrategy insertStrategy) {
             minKingdom = numKingdoms;
             maxSpecial = numSpecials;
-            kingdom = new ArrayList<>(minKingdom);
-            special = new ArrayList<>(maxSpecial);
+            kingdom = new CardCollection();
+            special = new CardCollection();
             costCard = (int)(Math.random() * minKingdom)+1;
             shelterCard = (int)(Math.random() * minKingdom)+1;
+
+            this.insertStrategy = insertStrategy;
         }
 
 
         /** Add an event to the supply */
         public void addSpecial(long id, boolean required) {
-            if(required) special.add(id);
-            else if(special.size() < maxSpecial)
-                special.add(id);
+            if(required) special.cards.add(id);
+            else if(special.cards.size() < maxSpecial)
+                special.cards.add(id);
         }
 
 
         /** Check if this shuffler needs a kingdom card */
         public boolean needsKingdom() {
-            return kingdom.size() < minKingdom;
+            return kingdom.cards.size() < minKingdom;
         }
 
 
         /** Add a kingdom card to the supply */
         public void addKingdom(long id, String cost, int set_id, boolean required) {
-            if(!required && minKingdom <= kingdom.size())
+            if(!required && minKingdom <= kingdom.cards.size())
                 return;
+            if (id == TableCard.ID_YOUNG_WITCH) waitingForBane = true; // YW will require a bane
 
-            // Special handling for the young witch
-            if(id == TableCard.ID_YOUNG_WITCH) {
-                if(bane == -1L) {
-                    // Do not add the young witch, wait for a bane card first
-                    baneStatus = BANE_WAITING;
-                    return;
-                } else {
-                    // Add the young witch, we have a bane card
-                    baneStatus = BANE_ACTIVE;
-                    minKingdom++;
-                }
-            }
-
-            // Special handling for the young witch's bane
-            else if("2".equals(cost) || "3".equals(cost)) {
-                bane = id;
-                if(baneStatus == BANE_WAITING)
-                    addKingdom(TableCard.ID_YOUNG_WITCH, "4", 3, true);
-            }
-
-            kingdom.add(id);
+            if (insertStrategy.handleKingdomInsertion(this, id, cost, set_id))
+                kingdom.cards.add(id);
 
             // determine if this is a high cost/shelters game
-            if(kingdom.size() == costCard)
+            if(kingdom.cards.size() == costCard)
                 high_cost = set_id == TableCard.SET_PROSPERITY;
-            if(kingdom.size() == shelterCard)
+            if(kingdom.cards.size() == shelterCard)
                 shelters = set_id == TableCard.SET_DARK_AGES;
         }
 
 
         /** Get all cards in this supply */
         public long[] getCards() {
-            long[] res = new long[kingdom.size() + special.size()];
+            long[] res = new long[kingdom.cards.size() + special.cards.size()];
             int i = 0;
-            for(Long card : kingdom) {
+            for(Long card : kingdom.cards) {
                 res[i] = card;
                 i++;
             }
-            for(Long card : special) {
+            for(Long card : special.cards) {
                 res[i] = card;
                 i++;
             }
@@ -241,20 +230,109 @@ class SupplyShuffler {
 
         /** Get the bane card of this supply */
         public long getBane() {
-            if(baneStatus == BANE_ACTIVE) return bane;
-            else return -1L;
+            return bane;
         }
 
+        /// Set the bane card for this supply
+        public void setBane(long id) {
+            bane = id;
+            waitingForBane = false;
+            minKingdom++; // bane is an extra card in the supply
+        }
 
         /** Get how many more kingdom cards we need */
         public int getShortfall() {
-            return minKingdom - kingdom.size();
+            return minKingdom - kingdom.cards.size();
         }
-
 
         /** Check if the supply is waiting for a valid bane card. */
         public boolean waitingForBane() {
-            return baneStatus == BANE_WAITING;
+            return waitingForBane;
+        }
+
+        public ShuffleSupply(Parcel parcel) {
+            minKingdom = parcel.readInt();
+            maxSpecial = parcel.readInt();
+            high_cost = parcel.readInt() != 0;
+            shelters = parcel.readInt() != 0;
+
+            costCard = parcel.readInt();
+            shelterCard = parcel.readInt();
+            bane = parcel.readLong();
+            waitingForBane = parcel.readInt() != 0;
+
+            kingdom = parcel.readParcelable(null);
+            special = parcel.readParcelable(null);
+            insertStrategy = new KingdomInsertAllStrategy(); // default to insert all strategy
+        }
+
+        @Override
+        public void writeToParcel(Parcel parcel, int flags) {
+            parcel.writeInt(minKingdom);
+            parcel.writeInt(maxSpecial);
+            parcel.writeInt(high_cost ? 1 : 0);
+            parcel.writeInt(shelters? 1 : 0);
+
+            parcel.writeInt(costCard);
+            parcel.writeInt(shelterCard);
+            parcel.writeLong(bane);
+            parcel.writeInt(waitingForBane ? 1 : 0);
+
+            parcel.writeParcelable(kingdom, flags);
+            parcel.writeParcelable(special, flags);
+        }
+
+        @Override
+        public int describeContents() { return 0; }
+
+        public static final Parcelable.Creator<ShuffleSupply> CREATOR = new Creator<ShuffleSupply>() {
+            @Override
+            public ShuffleSupply createFromParcel(Parcel parcel) {
+                return new ShuffleSupply(parcel);
+            }
+
+            @Override
+            public ShuffleSupply[] newArray(int size) {
+                return new ShuffleSupply[size];
+            }
+        };
+    }
+
+    static class KingdomInsertWithYWStrategy implements IKingdomInsertStrategy {
+        /** Possible value of {@link #baneStatus}. There is no young witch in the supply. */
+        private static final int BANE_INACTIVE = 0;
+        /** Possible value of {@link #baneStatus}.
+         *  The young witch was drawn, but we haven't seen a bane yet */
+        private static final int BANE_WAITING = 1;
+        /** Possible value of {@link #baneStatus}. The bane and the young witch have been set */
+        private static final int BANE_ACTIVE = 2;
+
+        /** Current status of the bane card */
+        private int baneStatus = BANE_INACTIVE;
+        /** Id for a possible bane card */
+        private long bane = -1L;
+        @Override
+        public boolean handleKingdomInsertion(ShuffleSupply supply, long id, String cost, int set_id) {
+            // Special handling for the young witch
+            if(id == TableCard.ID_YOUNG_WITCH) {
+                if(bane == -1L) {
+                    // Do not add the young witch, wait for a bane card first
+                    baneStatus = BANE_WAITING;
+                    return false;
+                } else {
+                    // Add the young witch, we have a bane card
+                    baneStatus = BANE_ACTIVE;
+                    supply.setBane(bane); // mark the bane card in the supply
+                }
+            }
+
+            // Special handling for the young witch's bane
+            else if("2".equals(cost) || "3".equals(cost)) {
+                bane = id;
+                if(baneStatus == BANE_WAITING)
+                    supply.addKingdom(TableCard.ID_YOUNG_WITCH, "4", 3, true);
+            }
+            return true;
         }
     }
 }

--- a/app/src/main/java/ca/marklauman/dominionpicker/SupplyShuffler.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/SupplyShuffler.java
@@ -29,7 +29,7 @@ class SupplyShuffler {
      * @param task optional. check if this task is cancelled for a premature return
      * @return SUCCESS when everything was ok, CANCELLED is task was cancelled, FAILED if shuffling failed
      */
-    static ShuffleResult FillSupply(ShuffleSupply supply,  @Nullable AsyncTask<?, ?, ?> task) {
+    static ShuffleResult fillSupply(ShuffleSupply supply, @Nullable AsyncTask<?, ?, ?> task) {
         if(!supply.needsKingdom())
             return ShuffleResult.SUCCESS;
 

--- a/app/src/main/java/ca/marklauman/dominionpicker/SupplyShuffler.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/SupplyShuffler.java
@@ -223,6 +223,10 @@ class SupplyShuffler {
             return res;
         }
 
+        public int getNumberOfCards() {
+            return kingdom.cards.size();
+        }
+
         /** Get the bane card of this supply */
         public long getBane() {
             return bane;
@@ -256,6 +260,7 @@ class SupplyShuffler {
             bane = parcel.readLong();
             waitingForBane = parcel.readInt() != 0;
 
+            numSpecials = parcel.readInt();
             kingdom = parcel.readParcelable(getClass().getClassLoader());
             insertStrategy = new KingdomInsertAllStrategy(); // default to insert all strategy
         }
@@ -272,6 +277,7 @@ class SupplyShuffler {
             parcel.writeLong(bane);
             parcel.writeInt(waitingForBane ? 1 : 0);
 
+            parcel.writeInt(numSpecials);
             parcel.writeParcelable(kingdom, flags);
         }
 

--- a/app/src/main/java/ca/marklauman/dominionpicker/SupplyShufflerTask.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/SupplyShufflerTask.java
@@ -105,7 +105,7 @@ public class SupplyShufflerTask extends AsyncTask<Void, Void, Void> {
 
     /** Broadcast a given message back to the activity */
     @SuppressWarnings("SameReturnValue")
-    private Void sendMsg(Intent msg) {
+    public static Void sendMsg(Intent msg) {
         try {
             LocalBroadcastManager.getInstance(Pref.getAppContext())
                     .sendBroadcast(msg);

--- a/app/src/main/java/ca/marklauman/dominionpicker/SupplyShufflerTask.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/SupplyShufflerTask.java
@@ -49,12 +49,12 @@ public class SupplyShufflerTask extends AsyncTask<Void, Void, Void> {
         SharedPreferences pref = Pref.get(Pref.getAppContext());
         final int minKingdom = pref.getInt(Pref.LIMIT_SUPPLY, 10);
         final int maxSpecial = pref.getInt(Pref.LIMIT_EVENTS, 2);
-        ShuffleSupply supply = new ShuffleSupply(minKingdom, maxSpecial);
+        ShuffleSupply supply = new ShuffleSupply(minKingdom, maxSpecial, new SupplyShuffler.KingdomInsertWithYWStrategy());
 
         ShuffleResult result = SupplyShuffler.fillSupply(supply, this);
         switch (result)
         {
-            case SUCCESS:   return successfulResult(supply);
+            case SUCCESS:   successfulResult(supply); return null;
             case CANCELLED: return cancelResult();
         }
 
@@ -82,7 +82,7 @@ public class SupplyShufflerTask extends AsyncTask<Void, Void, Void> {
 
     /** Generating the supply was successful.
      *  Write the result into the history database and tell the app its id number */
-    private Void successfulResult(ShuffleSupply supply) {
+    public static void successfulResult(ShuffleSupply supply) {
         // Insert the new supply
         long time = Calendar.getInstance().getTimeInMillis();
         ContentValues values = new ContentValues();
@@ -100,7 +100,7 @@ public class SupplyShufflerTask extends AsyncTask<Void, Void, Void> {
         Intent msg = new Intent(MSG_INTENT);
         msg.putExtra(MSG_RES, RES_OK);
         msg.putExtra(MSG_SUPPLY_ID, time);
-        return sendMsg(msg);
+        sendMsg(msg);
     }
 
     /** Broadcast a given message back to the activity */

--- a/app/src/main/java/ca/marklauman/dominionpicker/SupplyShufflerTask.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/SupplyShufflerTask.java
@@ -51,7 +51,7 @@ public class SupplyShufflerTask extends AsyncTask<Void, Void, Void> {
         final int maxSpecial = pref.getInt(Pref.LIMIT_EVENTS, 2);
         ShuffleSupply supply = new ShuffleSupply(minKingdom, maxSpecial);
 
-        ShuffleResult result = SupplyShuffler.FillSupply(supply, this);
+        ShuffleResult result = SupplyShuffler.fillSupply(supply, this);
         switch (result)
         {
             case SUCCESS:   return successfulResult(supply);

--- a/app/src/main/java/ca/marklauman/dominionpicker/SupplyShufflerTask.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/SupplyShufflerTask.java
@@ -1,0 +1,116 @@
+package ca.marklauman.dominionpicker;
+
+import android.content.ContentValues;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.AsyncTask;
+import android.support.v4.content.LocalBroadcastManager;
+import ca.marklauman.dominionpicker.database.DataDb;
+import ca.marklauman.dominionpicker.database.Provider;
+import ca.marklauman.dominionpicker.settings.Pref;
+import ca.marklauman.tools.Utils;
+import static ca.marklauman.dominionpicker.SupplyShuffler.ShuffleSupply;
+import static ca.marklauman.dominionpicker.SupplyShuffler.ShuffleResult;
+
+import java.util.Calendar;
+
+/** This task is used to shuffle new supplies.
+ *  It reads the current setting configuration when called, and attempts to create a supply
+ *  with the available cards.
+ *  The result of the shuffle is communicated to the main activity with broadcast intents.
+ *  @author Mark Lauman */
+public class SupplyShufflerTask extends AsyncTask<Void, Void, Void> {
+    /** When the shuffler is done, an intent of this type broadcasts
+     *  the results back to the activity.                         */
+    public static final String MSG_INTENT = "ca.marklauman.dominionpicker.shuffler";
+    /** The extra in the result intent containing the result id.
+     *  Will be a constant defined by this class starting with "RES_" */
+    public static final String MSG_RES = "result";
+    /** Extra containing card shortfall in the event of {@link #RES_MORE}.
+     *  String formatted as "X/Y" cards.  */
+    public static final String MSG_SHORT = "shortfall";
+    /** The extra containing the supply id. Only available on {@link #RES_OK}. */
+    public static final String MSG_SUPPLY_ID ="supply";
+
+    /** Shuffle succeeded. Supply available in {@link #MSG_SUPPLY_ID} */
+    public static final int RES_OK = 0;
+    /** Shuffle failed. No young witch targets. */
+    public static final int RES_NO_YW = 1;
+    /** Shuffle failed. Insufficient kingdom cards.
+     *  Shortfall in {@link #MSG_SHORT}. */
+    public static final int RES_MORE = 2;
+    /** Shuffle cancelled by outside source. */
+    @SuppressWarnings("WeakerAccess")
+    public static final int RES_CANCEL = 100;
+
+    @Override
+    protected Void doInBackground(Void... ignored) {
+        // Create the supply we will populate, and do a check for minKingdoms == 0
+        SharedPreferences pref = Pref.get(Pref.getAppContext());
+        final int minKingdom = pref.getInt(Pref.LIMIT_SUPPLY, 10);
+        final int maxSpecial = pref.getInt(Pref.LIMIT_EVENTS, 2);
+        ShuffleSupply supply = new ShuffleSupply(minKingdom, maxSpecial);
+
+        ShuffleResult result = SupplyShuffler.FillSupply(supply, this);
+        switch (result)
+        {
+            case SUCCESS:   return successfulResult(supply);
+            case CANCELLED: return cancelResult();
+        }
+
+        // Shuffle has failed. (assume result == ShuffleResult.FAILED)
+        Intent msg = new Intent(MSG_INTENT);
+        int shortfall = supply.getShortfall();
+        // Shuffle failed because there were no bane cards for the young witch
+        if(supply.waitingForBane() && shortfall == 1) {
+            msg.putExtra(MSG_RES, RES_NO_YW);
+            return sendMsg(msg);
+        } else {
+            msg.putExtra(MSG_RES, RES_MORE);
+            msg.putExtra(MSG_SHORT, supply.minKingdom-shortfall+"/"+supply.minKingdom);
+            return sendMsg(msg);
+        }
+    }
+
+    /** The shuffle was cancelled prematurely. */
+    private Void cancelResult() {
+        Intent cancel = new Intent(MSG_INTENT);
+        cancel.putExtra(MSG_RES, RES_CANCEL);
+        return sendMsg(cancel);
+    }
+
+
+    /** Generating the supply was successful.
+     *  Write the result into the history database and tell the app its id number */
+    private Void successfulResult(ShuffleSupply supply) {
+        // Insert the new supply
+        long time = Calendar.getInstance().getTimeInMillis();
+        ContentValues values = new ContentValues();
+        values.putNull(DataDb._H_NAME);
+        values.put(DataDb._H_TIME,      time);
+        values.put(DataDb._H_CARDS,     Utils.join(",", supply.getCards()));
+        values.put(DataDb._H_BANE,      supply.getBane());
+        values.put(DataDb._H_HIGH_COST, supply.high_cost);
+        values.put(DataDb._H_SHELTERS,  supply.shelters);
+        Pref.getAppContext()
+                .getContentResolver()
+                .insert(Provider.URI_HIST, values);
+
+        // let the listeners know the result
+        Intent msg = new Intent(MSG_INTENT);
+        msg.putExtra(MSG_RES, RES_OK);
+        msg.putExtra(MSG_SUPPLY_ID, time);
+        return sendMsg(msg);
+    }
+
+    /** Broadcast a given message back to the activity */
+    @SuppressWarnings("SameReturnValue")
+    private Void sendMsg(Intent msg) {
+        try {
+            LocalBroadcastManager.getInstance(Pref.getAppContext())
+                    .sendBroadcast(msg);
+        } catch(Exception ignored) {}
+        return null;
+    }
+
+}

--- a/app/src/main/java/ca/marklauman/dominionpicker/database/LoaderId.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/database/LoaderId.java
@@ -31,4 +31,6 @@ public abstract class LoaderId {
     public static final int RULES_DEBT = 13;
     /** The card info screen's loader */
     public static final int INFO_CARD = 14;
+    /** The drafter's card loader */
+    public static final int DRAFT_CARDS = 15;
 }

--- a/app/src/main/java/ca/marklauman/dominionpicker/database/LoaderId.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/database/LoaderId.java
@@ -31,6 +31,7 @@ public abstract class LoaderId {
     public static final int RULES_DEBT = 13;
     /** The card info screen's loader */
     public static final int INFO_CARD = 14;
-    /** The drafter's card loader */
-    public static final int DRAFT_CARDS = 15;
+    /** The drafter's card loader for choices and picks */
+    public static final int DRAFT_CARD_CHOICES = 15;
+    public static final int DRAFT_CARD_PICKS = 16;
 }

--- a/app/src/main/java/ca/marklauman/dominionpicker/settings/Pref.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/settings/Pref.java
@@ -49,6 +49,8 @@ public abstract class Pref implements OnSharedPreferenceChangeListener {
 
     /** Number of cards(choices) to present for each draft step*/
     public static final String DRAFT_NUMBER_OF_CHOICES = "draft_number_of_choices";
+    /** Number of picks made automatically, before presenting drafter interface*/
+    public static final String DRAFT_NUMBER_OF_PICKS = "draft_number_of_picks";
     /** Filter used to provide the correct card translation for each set.
      *  This is computed from {@link #FILT_LANG} and {@link #APP_LANG}
      *  when those preferences change. */
@@ -298,6 +300,8 @@ public abstract class Pref implements OnSharedPreferenceChangeListener {
             edit.putInt(ACTIVE_TAB, res.getInteger(R.integer.def_tab));
         if (!prefs.contains(DRAFT_NUMBER_OF_CHOICES))
             edit.putInt(DRAFT_NUMBER_OF_CHOICES, 3);
+        if (!prefs.contains(DRAFT_NUMBER_OF_PICKS))
+            edit.putInt(DRAFT_NUMBER_OF_PICKS, 0);
         edit.commit();
     }
 

--- a/app/src/main/java/ca/marklauman/dominionpicker/settings/Pref.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/settings/Pref.java
@@ -47,6 +47,8 @@ public abstract class Pref implements OnSharedPreferenceChangeListener {
     /** Filter used to specify required cards. */
     public static final String REQ_CARDS = "req_cards";
 
+    /** Number of cards(choices) to present for each draft step*/
+    public static final String DRAFT_NUMBER_OF_CHOICES = "draft_number_of_choices";
     /** Filter used to provide the correct card translation for each set.
      *  This is computed from {@link #FILT_LANG} and {@link #APP_LANG}
      *  when those preferences change. */
@@ -294,6 +296,8 @@ public abstract class Pref implements OnSharedPreferenceChangeListener {
             edit.putString(REQ_CARDS, "");
         if(!prefs.contains(ACTIVE_TAB))
             edit.putInt(ACTIVE_TAB, res.getInteger(R.integer.def_tab));
+        if (!prefs.contains(DRAFT_NUMBER_OF_CHOICES))
+            edit.putInt(DRAFT_NUMBER_OF_CHOICES, 3);
         edit.commit();
     }
 

--- a/app/src/main/java/ca/marklauman/dominionpicker/userinterface/recyclerview/AdapterCards.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/userinterface/recyclerview/AdapterCards.java
@@ -89,6 +89,8 @@ public class AdapterCards extends BasicTouchAdapter<AdapterCards.ViewHolder> {
     int _requires;
     /** Index of the landmark card type */
     int _type_landmark;
+    /** Index of the event card type */
+    int _type_event;
 
 
     /** Listener to be notified if a card is clicked. */
@@ -148,6 +150,7 @@ public class AdapterCards extends BasicTouchAdapter<AdapterCards.ViewHolder> {
         _type = cursor.getColumnIndex(TableCard._TYPE);
         _requires = cursor.getColumnIndex(TableCard._REQ);
         _type_landmark = cursor.getColumnIndex(TableCard._TYPE_LANDMARK);
+        _type_event = cursor.getColumnIndex(TableCard._TYPE_EVENT);
         notifyDataSetChanged();
     }
 
@@ -233,6 +236,12 @@ public class AdapterCards extends BasicTouchAdapter<AdapterCards.ViewHolder> {
     public int getSetId(int position) {
         mCursor.moveToPosition(position);
         return mCursor.getInt(_set_id);
+    }
+
+    /// @return true if the card at position is a landmark or event card
+    public boolean isSpecialCard(int position) {
+        mCursor.moveToPosition(position);
+        return mCursor.getInt(_type_landmark) != 0 || mCursor.getInt(_type_event) != 0;
     }
 
     /** Launch the details panel for a specified card */

--- a/app/src/main/java/ca/marklauman/dominionpicker/userinterface/recyclerview/AdapterCards.java
+++ b/app/src/main/java/ca/marklauman/dominionpicker/userinterface/recyclerview/AdapterCards.java
@@ -225,6 +225,15 @@ public class AdapterCards extends BasicTouchAdapter<AdapterCards.ViewHolder> {
         return mCursor.getString(_name);
     }
 
+    public String getCost(int position) {
+        mCursor.moveToPosition(position);
+        return mCursor.getString(_cost);
+    }
+
+    public int getSetId(int position) {
+        mCursor.moveToPosition(position);
+        return mCursor.getInt(_set_id);
+    }
 
     /** Launch the details panel for a specified card */
     public static void launchDetails(Context context, long cardId) {

--- a/app/src/main/res/layout/activity_drafter.xml
+++ b/app/src/main/res/layout/activity_drafter.xml
@@ -1,14 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
-    <android.support.v7.widget.RecyclerView
-            android:id="@android:id/list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="fill_vertical"
-    />
+<android.support.v4.widget.NestedScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    <LinearLayout
+                  android:orientation="vertical"
+                  android:layout_width="match_parent"
+                  android:layout_height="match_parent">
 
-    <!-- TODO: add currently picked elements -->
-</LinearLayout>
+        <TextView android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:paddingTop="8dp"
+                  android:paddingBottom="4dp"
+                  style="?android:attr/listSeparatorTextViewStyle"
+                  android:textColor="@color/colorPrimaryDark"
+                  android:background="@color/background"
+                  android:text="Pick one"
+        />
+
+        <android.support.v7.widget.RecyclerView
+                android:id="@+id/list_choices"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+        />
+
+        <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="horizontal"
+                      android:paddingTop="8dp"
+                      android:paddingBottom="4dp"
+        >
+            <TextView android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      style="?android:attr/listSeparatorTextViewStyle"
+                      android:textColor="@color/colorPrimaryDark"
+                      android:background="@color/background"
+                      android:text="Current picks "
+            />
+            <TextView android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+
+                      style="?android:attr/listSeparatorTextViewStyle"
+                      android:textColor="@color/colorPrimaryDark"
+                      android:background="@color/background"
+                      android:text="(0/10)"
+                      android:id="@+id/pick_progress"
+            />
+        </LinearLayout>
+
+
+        <android.support.v7.widget.RecyclerView
+                android:id="@+id/list_picks"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+        />
+    </LinearLayout>
+</android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/layout/activity_drafter.xml
+++ b/app/src/main/res/layout/activity_drafter.xml
@@ -3,11 +3,12 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent">
-
-    <Button
-            android:id="@+id/drafting_start"
+    <android.support.v7.widget.RecyclerView
+            android:id="@android:id/list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Start drafting"
+            android:layout_gravity="fill_vertical"
     />
+
+    <!-- TODO: add currently picked elements -->
 </LinearLayout>

--- a/app/src/main/res/layout/activity_drafter.xml
+++ b/app/src/main/res/layout/activity_drafter.xml
@@ -16,6 +16,7 @@
                   android:textColor="@color/colorPrimaryDark"
                   android:background="@color/background"
                   android:text="Pick one"
+                  android:id="@+id/pick_title"
         />
 
         <android.support.v7.widget.RecyclerView

--- a/app/src/main/res/layout/fragment_drafter.xml
+++ b/app/src/main/res/layout/fragment_drafter.xml
@@ -13,6 +13,13 @@
             android:text="Number of choices"
             android:id="@+id/pref_number_of_choices"
     />
+    <ca.marklauman.tools.preferences.SmallNumberPreference
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:key="draft_number_of_picks"
+            android:text="Number of picks"
+            android:id="@+id/pref_number_of_picks"
+    />
     <CheckBox
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_drafter.xml
+++ b/app/src/main/res/layout/fragment_drafter.xml
@@ -1,9 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
+    <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:text="Settings"
+            />
+    <ca.marklauman.tools.preferences.SmallNumberPreference
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:key="draft_number_of_choices"
+            android:text="Number of choices"
+    />
+    <CheckBox
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Reshuffle before each pick"
+            android:id="@+id/cbReshuffle"
+            android:layout_marginLeft="10dp"/>
     <Button
             android:id="@+id/drafting_start"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_drafter.xml
+++ b/app/src/main/res/layout/fragment_drafter.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <Button
+            android:id="@+id/drafting_start"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Start drafting"
+    />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_drafter.xml
+++ b/app/src/main/res/layout/fragment_drafter.xml
@@ -4,6 +4,14 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
+    <!-- TODO: move it to the DrafterActivity, put here options instead: cards/draft and to use landmarks or not-->
+    <android.support.v7.widget.RecyclerView
+            android:id="@android:id/list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="fill_vertical"
+             />
+
     <Button
             android:id="@+id/drafting_start"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_drafter.xml
+++ b/app/src/main/res/layout/fragment_drafter.xml
@@ -5,23 +5,19 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:text="Settings"
-            />
+
     <ca.marklauman.tools.preferences.SmallNumberPreference
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:key="draft_number_of_choices"
             android:text="Number of choices"
+            android:id="@+id/pref_number_of_choices"
     />
     <CheckBox
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Reshuffle before each pick"
-            android:id="@+id/cbReshuffle"
+            android:id="@+id/cb_reshuffle"
             android:layout_marginLeft="10dp"/>
     <Button
             android:id="@+id/drafting_start"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="market_pass">Pass</string>
     <string name="market_sold_out">Sold Out!</string>
 
+    <string name="drafter_title">Drafter</string>
+
     <string name="supply_no_name">Your Picks!</string>
     <string name="supply_colonies">Use Colonies &amp; Platinum</string>
     <string name="supply_shelters">Use Shelters</string>
@@ -48,6 +50,7 @@
         <item>@string/picker</item>
         <item>@string/games</item>
         <item>@string/market_title</item>
+        <item>@string/drafter_title</item>
     </string-array>
 
     <string-array name="historyTypes">


### PR DESCRIPTION
I added a new way to randomly pick cards, which I call drafter. Maybe it isn't the best name for it (I'm not a native English speaker). It's like a controlled random pick.

It works like this (when number of choices is 3):
1. 30 kingdom cards are randomly generated (mostly by the same algorithm as picker works)
2. the user is presented turn by turn with 3 cards, and he is able to choose one of them
3. step 2 is repeated until the conditions for a valid game setup are met (like 10 kingdom cards are selected) 
4. the pick results are shown (the same way as the picker)

There are some tweaks, like the support for event and landmark cards, so in reality 34 cards are picked, instead the 30 described above (30 for the 10 kingdom cards, 2*3=6 for the event cards, but if most two events are selected, 28 kingdom cards are enough for the rest of the picks).
Selecting bane cards (when YW is selected) works differently: a new pick is made at the end for 3 kingdom cards, which could be used as banes. The user is presented with an extra pick ("Pick a bane") with the 3 candidates.
Other options include:
- autopicks: it means how many cards are picked randomly by the app. The rest of the cards is drafted, with the process above
- reshuffle before each pick (not implemented): do not shuffle all the cards in the beginning, instead reshuffle the available cards each time, before the choice is presented (this means that some cards can come up more than once, if you dismiss them)

I wanted to reuse as much from your original code as possible, that's why SupplyShuffler is affected so much by the changes (for details see the commits).

I tried to handle all kinds of errors, and have tested it as much as I could on my phone.
Despite my efforts, there could be some errors in the code. That's one reason why I left the code on the feature branch: you can tweak/fix it before integrating into master.

I made some sacrifices (alias hacks), so I can move along with greater speed:
- not all strings are localized (they aren't present in strings.xml)
- the icon for drafter just reuses the "code" icon from the about menu
- reshuffle before each pick doesn't work (it could be hidden, until  it's implemented)
- no help text/tutorial is added (I hope this description helps)

You can fix them, if you want, or if you write me the details how to localize, and what icon to choose I'm happy to add them.

Hope you like the "drafter". We are using it constantly with our gaming group, and we like it so far very much (try it with number of picks set to 2). It feels like you are getting better sets, but still with a good variety.
